### PR TITLE
Bump mixpanel client

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "bluebird": "^3.4.7",
-    "resin-universal-mixpanel": "^2.3.1"
+    "resin-universal-mixpanel": "^2.4.0"
   },
   "devDependencies": {
     "resin-lint": "^1.4.0"


### PR DESCRIPTION
This updated nodejs client. One of important changes is switch to https
by default.

See https://github.com/balena-io-modules/resin-event-log/pull/11

Change-type: minor
Signed-off-by: Roman Mazur <mazur.roman@gmail.com>